### PR TITLE
Enhancement for unread topics

### DIFF
--- a/web/app/themes/huskies-theme/functions/bbpress/forum.php
+++ b/web/app/themes/huskies-theme/functions/bbpress/forum.php
@@ -23,19 +23,8 @@ class Forum extends Base {
   function is_unread() {
     if (isset($this->unread)) return $this->unread;
 
-    $query = array(
-      'post_type' => bbp_get_topic_post_type(),
-      'post_parent' => $this->id,
-      'meta_key' => 'bbppu_read_by',
-      'meta_value' => 'i:'.bbp_get_current_user_id(),
-      'meta_compare' => 'NOT LIKE',
-      'orderby' => 'title',
-      'order' => 'DESC',
-      'nopaging' => true
-    );
-
-    $topics = new WP_Query($query);
-    $this->unread = count($topics->posts) > 0;
+    $topics = new WP_Query(get_unread_topic_query_args($this->id));
+    $this->unread = $topics->found_posts > 0;
 
     return $this->unread;
   }

--- a/web/app/themes/huskies-theme/functions/timber.php
+++ b/web/app/themes/huskies-theme/functions/timber.php
@@ -40,22 +40,36 @@ function add_to_context($data){
   return $data;
 }
 
+function get_unread_topic_query_args($parent_id='any') {
+  if (!is_user_logged_in()) {
+    return 0 ;
+  }
+
+  $user = wp_get_current_user();
+  return array(
+    'post_type' => bbp_get_topic_post_type(),
+    'post_parent' => $parent_id,
+    'meta_query' => array(
+      'relation' => 'AND',
+      'unread_clause' => array(
+          'key' => 'bbppu_read_by',
+          'value' => 'i:'.$user->ID,
+          'compare' => 'NOT LIkE'
+      ),
+      'last_modified_clause' => array(
+          'key' => '_bbp_last_active_time',
+          'value' => $user->user_registered,
+          'compare' => '>'
+      ),
+    ),
+  );
+};
+
 function get_unread_counts() {
   if (!is_user_logged_in()) {
     return 0 ;
   }
 
-  $query = array(
-    'post_type' => bbp_get_topic_post_type(),
-    'post_parent' => 'any',
-    'meta_key' => 'bbppu_read_by',
-    'meta_value' => 'i:'.bbp_get_current_user_id(),
-    'meta_compare' => 'NOT LIKE',
-    'orderby' => 'title',
-    'order' => 'DESC',
-    'nopaging' => true
-  );
-
-  $topics = new WP_Query($query);
-  return count($topics->posts);
+  $topics = new WP_Query(get_unread_topic_query_args());
+  return $topics->found_posts;
 }

--- a/web/app/themes/huskies-theme/page-forum.php
+++ b/web/app/themes/huskies-theme/page-forum.php
@@ -6,16 +6,11 @@ if (!bbp_has_forums(array('orderby' => 'title'))) {
   abort($context, __('No Forums', 'huskies'));
 }
 
-$query = array(
-  'post_type' => bbp_get_topic_post_type(),
-  'post_parent' => 'any',
-  'meta_key' => 'bbppu_read_by',
-  'meta_value' => 'i:'.bbp_get_current_user_id(),
-  'meta_compare' => 'NOT LIKE',
-  'orderby' => 'title',
-  'order' => 'DESC',
-  'nopaging' => true
-);
+$query = get_unread_topic_query_args();
+$query['posts_per_page'] = 5;
+$query['orderby'] = 'last_modified_clause';
+$query['order'] = 'DESC';
+$query['nopaging'] = false;
 
 $context['unread_topics'] = Timber::get_posts(new WP_Query($query), 'Topic');
 $context['forums'] = Timber::get_posts(bbpress()->forum_query, 'Forum');

--- a/web/app/themes/huskies-theme/scripts/header.coffee
+++ b/web/app/themes/huskies-theme/scripts/header.coffee
@@ -10,7 +10,7 @@ run = ($main, $header, $body) ->
 
 $ ->
   $header = $('.header-nav')
-  $body = $('body')
+  $body = $(document)
   $main = $('main')
 
   $(window).on 'scroll', run.bind(@, $main, $header, $body)

--- a/web/app/themes/huskies-theme/scripts/slideshow.coffee
+++ b/web/app/themes/huskies-theme/scripts/slideshow.coffee
@@ -1,7 +1,7 @@
 run = ($slides) ->
   changeTime = 5000
   mainOffset = $('main').offset().top
-  $body = $('body')
+  $body = $(document)
   $slideshow = $('.slideshow')
   $pbOverlay = $('#pbOverlay')
 

--- a/web/app/themes/huskies-theme/views/forum/forums.twig
+++ b/web/app/themes/huskies-theme/views/forum/forums.twig
@@ -8,7 +8,7 @@
 {% block forum_header %}
   {% if unread_topics|length > 0 %}
     <section class="section section--inverse">
-      <h1 class="section__title center">{{ __('%s Unread Topics', 'huskies')|format(unread_topics|length) }}</h1>
+      <h1 class="section__title center">{{ __('%s Unread Topics', 'huskies')|format(page.user.profile.unread_topics) }}</h1>
       {% for index, topic in unread_topics %}
         {{ topic(topic, true) }}
       {% endfor %}


### PR DESCRIPTION
NEW:
- no unread topics before user's registered date
- show maximum of 5 unread on forum main page

Questions:
There is a new global function to retrieve query arguments for unread topics (get_unread_topic_query_args()). It is currently located in timber.php. Is there a better location for putting these kind of global forum related functions?